### PR TITLE
Include an option to complete only required params

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -28,9 +28,10 @@ module.exports =
       title: 'Add Bracket After Function'
       description: 'Adds an opening bracket after a function, because that’s normal behaviour.'
     useSnippets:
-      type: 'boolean'
-      default: false
-      title: 'Complete with snippets'
+      type: 'string'
+      default: 'none'
+      enum: ['none', 'all', 'required']
+      title: 'Autocomplete Function Parameters'
       description: 'Allows to complete functions with their arguments. Use completion key to jump between arguments. Will ignore some settings if used.'
     pythonPath:
       type: 'string'


### PR DESCRIPTION
Hi. Since we have to enable parameters completion (aka "Complete with snippets") to get auto add brackets (#26), I've decided to make an option to choose between none, all parameters and only required.

Well this is the first time that I mess with Atom, I hope that I haven't broken anything.