### PR TITLE
fix bug when current file is in non-english path

### DIFF
--- a/lib/completion.py
+++ b/lib/completion.py
@@ -1,4 +1,5 @@
 import os
+import io
 import sys
 import json
 import traceback
@@ -21,6 +22,7 @@ class JediCompletion(object):
 
   def __init__(self):
     self.default_sys_path = sys.path
+    self._input = io.TextIOWrapper(sys.stdin.buffer, encoding='utf-8')
 
   def _get_completion_type(self, completion):
     is_built_in = completion.in_builtin_module
@@ -174,7 +176,7 @@ class JediCompletion(object):
   def watch(self):
     while True:
       try:
-        self._process_request(sys.stdin.readline())
+        self._process_request(self._input.readline())
       except Exception:
         traceback.print_exc(file=sys.stderr)
 


### PR DESCRIPTION
The package do not work when current file is in a path with Chinese characters.

The problem is because the encoding of sys.stdin is set to 'GBK' however the acuatually encoding is 'utf-8'.  

I did some fix and it works for me. 