### PR TITLE
Immediately show definition if only one matches

### DIFF
--- a/lib/definitions-view.coffee
+++ b/lib/definitions-view.coffee
@@ -5,6 +5,7 @@ module.exports =
 class DefinitionsView extends SelectListView
   initialize: (matches) ->
     super
+    @storeFocusedElement()
     @addClass('symbols-view')
     @panel ?= atom.workspace.addModalPanel(item: this)
     @panel.show()
@@ -39,4 +40,4 @@ class DefinitionsView extends SelectListView
       editor.scrollToCursorPosition()
 
   cancelled: ->
-    @panel.hide()
+    @panel?.hide()

--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -78,12 +78,13 @@ module.exports =
     atom.commands.add 'atom-text-editor[data-grammar~=python]', 'autocomplete-python:go-to-definition', =>
       if @definitionsView
         @definitionsView.destroy()
-        @definitionsView = null
       @definitionsView = new DefinitionsView()
       editor = atom.workspace.getActiveTextEditor()
       bufferPosition = editor.getCursorBufferPosition()
       @getDefinitions({editor, bufferPosition}).then (results) =>
         @definitionsView.setItems(results)
+        if results.length == 1
+          @definitionsView.confirmed(results[0])
 
   _serialize: (request) ->
     return JSON.stringify(request)


### PR DESCRIPTION
Also fixed a bug that caused focus to be lost when the definition list was cancelled.