### PR TITLE
Remove redundant information

### DIFF
--- a/lib/completion.py
+++ b/lib/completion.py
@@ -97,11 +97,15 @@ class JediCompletion(object):
         """
         _completions = []
         for completion in completions:
+            if self.show_doc_strings:
+                description = completion.docstring()
+            else:
+                description = self._generate_signature(completion)
             _completion = {
                 'snippet': self._generate_snippet(completion),
                 'type': self._get_definition_type(completion),
-                'description': self._generate_signature(completion),
-                'rightLabel': self._additional_info(completion),
+                'description': description,
+                'rightLabel': self._additional_info(completion)
             }
             _completions.append(_completion)
         return json.dumps({'id': identifier, 'results': _completions})
@@ -152,10 +156,13 @@ class JediCompletion(object):
         """
         sys.path = self.default_sys_path
         self.use_snippets = config.get('useSnippets')
+        self.show_doc_strings = config.get('showDescriptions', True)
         jedi.settings.case_insensitive_completion = config.get(
             'caseInsensitiveCompletion', True)
         jedi.settings.add_dot_after_module = config.get(
             'addDotAfterModule', False)
+        jedi.settings.add_bracket_after_function = config.get(
+            'addBracketAfterFunction', False)
         jedi.settings.add_bracket_after_function = config.get(
             'addBracketAfterFunction', False)
         for path in config.get('extraPaths', []):

--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -117,6 +117,8 @@ module.exports =
         'autocomplete-python.addDotAfterModule')
       'addBracketAfterFunction': atom.config.get(
         'autocomplete-python.addBracketAfterFunction')
+      'showDescriptions': atom.config.get(
+        'autocomplete-python.showDescriptions')
     return args
 
   getSuggestions: ({editor, bufferPosition, scopeDescriptor, prefix}) ->

--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -117,8 +117,6 @@ module.exports =
         'autocomplete-python.addDotAfterModule')
       'addBracketAfterFunction': atom.config.get(
         'autocomplete-python.addBracketAfterFunction')
-      'showDescriptions': atom.config.get(
-        'autocomplete-python.showDescriptions')
     return args
 
   getSuggestions: ({editor, bufferPosition, scopeDescriptor, prefix}) ->

--- a/spec/provider-spec.coffee
+++ b/spec/provider-spec.coffee
@@ -38,8 +38,8 @@ describe 'Python autocompletions', ->
         waitsForPromise ->
           getCompletions().then (completions) ->
             for completion in completions
-              expect(completion.text.length).toBeGreaterThan 0
-              expect(completion.text).toBe 'isinstance'
+              expect(completion.snippet.length).toBeGreaterThan 0
+              expect(completion.snippet).toBe 'isinstance'
             expect(completions.length).toBe 1
 
       it 'autocompletes python keywords', ->
@@ -50,8 +50,8 @@ describe 'Python autocompletions', ->
           getCompletions().then (completions) ->
             for completion in completions
               if completion.type == 'keyword'
-                expect(completion.text).toBe 'import'
-              expect(completion.text.length).toBeGreaterThan 0
+                expect(completion.snippet).toBe 'import'
+              expect(completion.snippet.length).toBeGreaterThan 0
             expect(completions.length).toBe 3
 
       it 'autocompletes defined functions', ->
@@ -64,5 +64,5 @@ describe 'Python autocompletions', ->
         completions = getCompletions()
         waitsForPromise ->
           getCompletions().then (completions) ->
-            expect(completions[0].text).toBe 'hello_world'
+            expect(completions[0].snippet).toBe 'hello_world'
             expect(completions.length).toBe 1


### PR DESCRIPTION
This changes a number of things:

 * snippets are always used but their brevity can be adjusted as usual
 * right column is only displayed for constants (other types have icons that indicate their type)
 * call signature is always displayed instead of docstrings as lack of formatting makes docstring unreadable (also removed the setting allowing to hide it as it is always useful)