### PR TITLE
[WIP] Autocomplete function arguments on bracket

### DIFF
--- a/lib/completion.py
+++ b/lib/completion.py
@@ -8,8 +8,6 @@ import jedi
 # remove jedi from path after we import it so it will not be completed
 sys.path.pop(0)
 
-unicode = str if 'unicode' not in dir(__builtins__) else unicode
-
 
 class JediCompletion(object):
     basic_types = {

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -48,3 +48,6 @@ module.exports =
   deactivate: -> provider.dispose()
 
   getProvider: -> provider
+
+  consumeSnippets: (snippetsManager) ->
+    provider.setSnippetsManager snippetsManager

--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -1,3 +1,4 @@
+{Disposable, CompositeDisposable} = require 'atom'
 path = require 'path'
 DefinitionsView = require './definitions-view'
 
@@ -76,7 +77,9 @@ module.exports =
     @readline = require('readline').createInterface(input: @provider.stdout)
     @readline.on 'line', (response) => @_deserialize(response)
 
-    atom.commands.add 'atom-text-editor[data-grammar~=python]', 'autocomplete-python:go-to-definition', =>
+    editorSelector = 'atom-text-editor[data-grammar~=python]'
+    commandName = 'autocomplete-python:go-to-definition'
+    atom.commands.add editorSelector, commandName, =>
       if @definitionsView
         @definitionsView.destroy()
       @definitionsView = new DefinitionsView()
@@ -86,6 +89,18 @@ module.exports =
         @definitionsView.setItems(results)
         if results.length == 1
           @definitionsView.confirmed(results[0])
+
+    disposables = new CompositeDisposable()
+    addEventListener = (editor, eventName, handler) ->
+      editorView = atom.views.getView editor
+      editorView.addEventListener eventName, handler
+      new Disposable ->
+        editor.removeEventListener eventName, handler
+    atom.workspace.observeTextEditors (editor) =>
+      if editor.getGrammar().scopeName == 'source.python'
+        disposables.add addEventListener editor, 'keyup', (event) =>
+          if event.shiftKey and event.keyCode == 57
+            @_completeArguments(editor, editor.getCursorBufferPosition())
 
   _serialize: (request) ->
     return JSON.stringify(request)
@@ -125,26 +140,35 @@ module.exports =
 
   setSnippetsManager: (@snippetsManager) ->
 
-  getSuggestions: ({editor, bufferPosition, scopeDescriptor, prefix}) ->
+  _completeArguments: (editor, bufferPosition) ->
     payload =
       id: @_generateRequestId(editor, bufferPosition)
+      lookup: 'arguments'
       path: editor.getPath()
       source: editor.getText()
       line: bufferPosition.row
       column: bufferPosition.column
       config: @_generateRequestConfig()
 
-    if prefix == '('
-      payload['lookup'] = 'arguments'
-      @provider.stdin.write(@_serialize(payload) + '\n')
-      return new Promise =>
-        @requests[payload.id] = editor
+    @provider.stdin.write(@_serialize(payload) + '\n')
 
+    return new Promise =>
+      @requests[payload.id] = editor
+
+  getSuggestions: ({editor, bufferPosition, scopeDescriptor, prefix}) ->
     if prefix not in ['.', ' '] and (prefix.length < 1 or /\W/.test(prefix))
       return []
+    payload =
+      id: @_generateRequestId(editor, bufferPosition)
+      lookup: 'completions'
+      path: editor.getPath()
+      source: editor.getText()
+      line: bufferPosition.row
+      column: bufferPosition.column
+      config: @_generateRequestConfig()
 
-    payload['lookup'] = 'completions'
     @provider.stdin.write(@_serialize(payload) + '\n')
+
     return new Promise (resolve) =>
       @requests[payload.id] = resolve
 

--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -14,6 +14,7 @@ module.exports =
   constructor: ->
     @requests = {}
     @definitionsView = null
+    @snippetsManager = null
 
     env = process.env
     pythonPath = atom.config.get('autocomplete-python.pythonPath')
@@ -94,7 +95,7 @@ module.exports =
     if response['arguments']
       console.log('Expanding function arguments:', response['arguments'])
       editor = @requests[response['id']]
-      editor.insertText(response['arguments'])
+      @snippetsManager?.insertSnippet(response['arguments'], editor)
     else
       resolve = @requests[response['id']]
       resolve(response['results'])
@@ -121,6 +122,8 @@ module.exports =
       'showDescriptions': atom.config.get(
         'autocomplete-python.showDescriptions')
     return args
+
+  setSnippetsManager: (@snippetsManager) ->
 
   getSuggestions: ({editor, bufferPosition, scopeDescriptor, prefix}) ->
     payload =

--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -108,12 +108,15 @@ module.exports =
   _deserialize: (response) ->
     response = JSON.parse(response)
     if response['arguments']
-      console.log('Expanding function arguments:', response['arguments'])
       editor = @requests[response['id']]
-      @snippetsManager?.insertSnippet(response['arguments'], editor)
+      bufferPosition = editor.getCursorBufferPosition()
+      # Compare response ID with current state to avoid stale completions
+      if response['id'] == @_generateRequestId(editor, bufferPosition)
+        @snippetsManager?.insertSnippet(response['arguments'], editor)
     else
       resolve = @requests[response['id']]
       resolve(response['results'])
+    delete @requests[response['id']]
 
   _generateRequestId: (editor, bufferPosition) ->
     return require('crypto').createHash('md5').update([

--- a/package.json
+++ b/package.json
@@ -20,6 +20,13 @@
       }
     }
   },
+  "consumedServices": {
+    "snippets": {
+      "versions": {
+        "0.1.0": "consumeSnippets"
+      }
+    }
+  },
   "contributors": [
     {
       "name": "Dmitry Sadovnychyi",

--- a/spec/provider-spec.coffee
+++ b/spec/provider-spec.coffee
@@ -38,8 +38,8 @@ describe 'Python autocompletions', ->
         waitsForPromise ->
           getCompletions().then (completions) ->
             for completion in completions
-              expect(completion.snippet.length).toBeGreaterThan 0
-              expect(completion.snippet).toBe 'isinstance$0'
+              expect(completion.text.length).toBeGreaterThan 0
+              expect(completion.text).toBe 'isinstance$0'
             expect(completions.length).toBe 1
 
       it 'autocompletes python keywords', ->
@@ -50,8 +50,8 @@ describe 'Python autocompletions', ->
           getCompletions().then (completions) ->
             for completion in completions
               if completion.type == 'keyword'
-                expect(completion.snippet).toBe 'import$0'
-              expect(completion.snippet.length).toBeGreaterThan 0
+                expect(completion.text).toBe 'import$0'
+              expect(completion.text.length).toBeGreaterThan 0
             expect(completions.length).toBe 3
 
       it 'autocompletes defined functions', ->
@@ -64,5 +64,5 @@ describe 'Python autocompletions', ->
         completions = getCompletions()
         waitsForPromise ->
           getCompletions().then (completions) ->
-            expect(completions[0].snippet).toBe 'hello_world$0'
+            expect(completions[0].text).toBe 'hello_world$0'
             expect(completions.length).toBe 1


### PR DESCRIPTION
Idea is to autocomplete function arguments only when you type a bracket.
It is done with simple `editor.insertText` thus many bugs could occur. Snippet is not formatted.

- [x] Make snippet work
- [x] Do not insert arguments when bracket is being removed (with completions on backspace turned on)
- [x] Will it work properly on slow machines due to async calls and probably stale editor position? 

![sample](https://cloud.githubusercontent.com/assets/193864/10631697/435f50be-7812-11e5-9900-f2d5761c4230.gif)

#83 #87 
