### PR TITLE
Implement fuzzy filtering, treat args as variables

### DIFF
--- a/lib/completion.py
+++ b/lib/completion.py
@@ -76,8 +76,10 @@ class JediCompletion(object):
         _completions = []
 
         for call_signature in script.call_signatures():
-            for param in call_signature.params:
+            for pos, param in enumerate(call_signature.params):
                 if not param.name:
+                    continue
+                if param.name == 'self' and pos == 0:
                     continue
                 try:
                     name, value = param.description.split('=')
@@ -126,8 +128,10 @@ class JediCompletion(object):
         arguments = []
         i = 1
         for call_signature in script.call_signatures():
-            for param in call_signature.params:
+            for pos, param in enumerate(call_signature.params):
                 if not param.name:
+                    continue
+                if param.name == 'self' and pos == 0:
                     continue
                 try:
                     name, value = param.description.split('=')

--- a/lib/completion.py
+++ b/lib/completion.py
@@ -63,13 +63,12 @@ class JediCompletion(object):
             completion.name,
             ', '.join(param.description for param in completion.params))
 
-    def _serialize_completions(self, script, identifier=None, prefix=''):
+    def _serialize_completions(self, script, identifier=None):
         """Serialize response to be read from Atom.
 
         Args:
           script: Instance of jedi.api.Script object.
           identifier: Unique completion identifier to pass back to Atom.
-          prefix: String with prefix to filter function arguments.
 
         Returns:
           Serialized string to send to Atom.
@@ -85,21 +84,19 @@ class JediCompletion(object):
                 except ValueError:
                     name = param.description
                     value = None
-                if not name.lower().startswith(prefix.lower()):
-                    continue
                 _completion = {
-                    'type': 'property',
+                    'type': 'variable',
                     'rightLabel': self._additional_info(call_signature)
                 }
                 if value:
                     _completion['snippet'] = '%s=${1:%s}$0' % (name, value)
                 else:
-                    _completion['snippet'] = '%s$0' % name
+                    _completion['snippet'] = '%s=$1$0' % name
                 if self.show_doc_strings:
                     _completion['description'] = call_signature.docstring()
                 else:
                     _completion['description'] = self._generate_signature(
-                      call_signature)
+                        call_signature)
                 _completions.append(_completion)
 
         for completion in script.completions():
@@ -108,7 +105,7 @@ class JediCompletion(object):
             else:
                 description = self._generate_signature(completion)
             _completion = {
-                'text': completion.name,
+                'snippet': '%s$0' % (completion.name,),
                 'type': self._get_definition_type(completion),
                 'description': description,
                 'rightLabel': self._additional_info(completion)
@@ -225,8 +222,7 @@ class JediCompletion(object):
                 script, request['id']))
         else:
             return self._write_response(
-                self._serialize_completions(script, request['id'],
-                                            request['prefix']))
+                self._serialize_completions(script, request['id']))
 
     def _write_response(self, response):
         sys.stdout.write(response + '\n')

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "atom": ">=0.194.0 <2.0.0"
   },
   "dependencies": {
-    "atom-space-pen-views": "~2.1.0"
+    "atom-space-pen-views": "~2.1.0",
+    "fuzzaldrin": "~2.1.0"
   },
   "package-dependencies": {},
   "providedServices": {

--- a/spec/provider-spec.coffee
+++ b/spec/provider-spec.coffee
@@ -38,8 +38,8 @@ describe 'Python autocompletions', ->
         waitsForPromise ->
           getCompletions().then (completions) ->
             for completion in completions
-              expect(completion.text.length).toBeGreaterThan 0
-              expect(completion.text).toBe 'isinstance'
+              expect(completion.snippet.length).toBeGreaterThan 0
+              expect(completion.snippet).toBe 'isinstance$0'
             expect(completions.length).toBe 1
 
       it 'autocompletes python keywords', ->
@@ -50,9 +50,10 @@ describe 'Python autocompletions', ->
           getCompletions().then (completions) ->
             for completion in completions
               if completion.type == 'keyword'
-                expect(completion.text).toBe 'import'
-              expect(completion.text.length).toBeGreaterThan 0
-            expect(completions.length).toBe 3
+                expect(completion.snippet).toBe 'import$0'
+              expect(completion.snippet.length).toBeGreaterThan 0
+            console.log completions
+            expect(completions.length).toBe 5
 
       it 'autocompletes defined functions', ->
         editor.setText """
@@ -64,5 +65,5 @@ describe 'Python autocompletions', ->
         completions = getCompletions()
         waitsForPromise ->
           getCompletions().then (completions) ->
-            expect(completions[0].text).toBe 'hello_world'
+            expect(completions[0].snippet).toBe 'hello_world$0'
             expect(completions.length).toBe 1


### PR DESCRIPTION
Also added trailing `=` after non-keyword arguments as the only reason to complete I can think of is to pass them as keyword args.