### PR TITLE
[WIP] Add hyperclick support for go-to-definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Python packages, variables, methods and functions with their arguments autocompl
 * Prints first N characters of statement value while completing variables
 * Prints function arguments while completing functions
 * Go-to-definition functionality, by default on `Alt+Cmd+G`/`Ctrl+Alt+G` (thanks to [@patrys](https://github.com/patrys))
+* If you have [Hyperclick](https://atom.io/packages/hyperclick) installed – you can click on anything to go-to-definition
+![sample](https://cloud.githubusercontent.com/assets/193864/10814177/17fb8bce-7e5f-11e5-8285-6b0100b3a0f8.gif)
 
 # Configuration
 

--- a/lib/hyperclickProvider.coffee
+++ b/lib/hyperclickProvider.coffee
@@ -9,8 +9,8 @@ module.exports =
   getSuggestionForWord: (editor, text, range) ->
     if editor.getGrammar().scopeName == 'source.python'
       if atom.config.get('autocomplete-python.outputDebug')
-        console.debug range.start, @_getScopes(editor, range.start)
-        console.debug range.end, @_getScopes(editor, range.end)
+        provider._log range.start, @_getScopes(editor, range.start)
+        provider._log range.end, @_getScopes(editor, range.end)
       callback = ->
         provider.goToDefinition()
       return {range, callback}

--- a/lib/hyperclickProvider.coffee
+++ b/lib/hyperclickProvider.coffee
@@ -1,0 +1,16 @@
+provider = require './provider'
+
+module.exports =
+  priority: 1
+
+  _getScopes: (editor, range) ->
+    return editor.scopeDescriptorForBufferPosition(range).scopes
+
+  getSuggestionForWord: (editor, text, range) ->
+    if editor.getGrammar().scopeName == 'source.python'
+      if atom.config.get('autocomplete-python.outputDebug')
+        console.debug range.start, @_getScopes(editor, range.start)
+        console.debug range.end, @_getScopes(editor, range.end)
+      callback = ->
+        provider.goToDefinition()
+      return {range, callback}

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -1,4 +1,5 @@
 provider = require './provider'
+hyperclickProvider = require './hyperclickProvider'
 
 module.exports =
   config:
@@ -54,6 +55,8 @@ module.exports =
   deactivate: -> provider.dispose()
 
   getProvider: -> provider
+
+  getHyperclickProvider: -> hyperclickProvider
 
   consumeSnippets: (snippetsManager) ->
     provider.setSnippetsManager snippetsManager

--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -72,15 +72,7 @@ module.exports =
     editorSelector = 'atom-text-editor[data-grammar~=python]'
     commandName = 'autocomplete-python:go-to-definition'
     atom.commands.add editorSelector, commandName, =>
-      if @definitionsView
-        @definitionsView.destroy()
-      @definitionsView = new DefinitionsView()
-      editor = atom.workspace.getActiveTextEditor()
-      bufferPosition = editor.getCursorBufferPosition()
-      @getDefinitions({editor, bufferPosition}).then (results) =>
-        @definitionsView.setItems(results)
-        if results.length == 1
-          @definitionsView.confirmed(results[0])
+      @goToDefinition
 
     disposables = new CompositeDisposable()
     addEventListener = (editor, eventName, handler) ->
@@ -206,7 +198,7 @@ module.exports =
           matches = filter(matches, prefix, key: 'snippet')
         resolve(matches)
 
-  getDefinitions: ({editor, bufferPosition}) ->
+  getDefinitions: (editor, bufferPosition) ->
     payload =
       id: @_generateRequestId(editor, bufferPosition)
       lookup: 'definitions'
@@ -219,6 +211,17 @@ module.exports =
     @_sendRequest(@_serialize(payload))
     return new Promise (resolve) =>
       @requests[payload.id] = resolve
+
+  goToDefinition: ->
+    if @definitionsView
+      @definitionsView.destroy()
+    @definitionsView = new DefinitionsView()
+    editor = atom.workspace.getActiveTextEditor()
+    bufferPosition = editor.getCursorBufferPosition()
+    @getDefinitions(editor, bufferPosition).then (results) =>
+      @definitionsView.setItems(results)
+      if results.length == 1
+        @definitionsView.confirmed(results[0])
 
   dispose: ->
     @provider.kill()

--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -89,7 +89,7 @@ module.exports =
     editorSelector = 'atom-text-editor[data-grammar~=python]'
     commandName = 'autocomplete-python:go-to-definition'
     atom.commands.add editorSelector, commandName, =>
-      @goToDefinition
+      @goToDefinition()
 
     atom.workspace.observeTextEditors (editor) =>
       editor.displayBuffer.onDidChangeGrammar (grammar) =>

--- a/package.json
+++ b/package.json
@@ -19,6 +19,11 @@
       "versions": {
         "2.0.0": "getProvider"
       }
+    },
+    "hyperclick.provider": {
+      "versions": {
+        "0.0.0": "getHyperclickProvider"
+      }
     }
   },
   "consumedServices": {


### PR DESCRIPTION
[Hyperclick](https://atom.io/packages/hyperclick) can use autocomplete-python as one of providers. 

![sample](https://cloud.githubusercontent.com/assets/193864/10814177/17fb8bce-7e5f-11e5-8285-6b0100b3a0f8.gif)

Click on anything while holding CMD to trigger go-to-definition.

- [ ] Does not works great with hyperclick's default keystrokes since CMD used for multi cursors
- [ ] It allows to click on anything, even on keywords. We should filter them out somehow, likely by using scopes

@eMerzh check this out, as this was your idea.