### PR TITLE
Support `source python django` in the grammer

### DIFF
--- a/keymaps/autocomplete-python.cson
+++ b/keymaps/autocomplete-python.cson
@@ -1,8 +1,8 @@
-'.platform-darwin atom-text-editor[data-grammar="source python"]:not(.mini)':
+'.platform-darwin atom-text-editor[data-grammar~=python]:not(.mini)':
   'alt-cmd-g': 'autocomplete-python:go-to-definition'
 
-'.platform-linux atom-text-editor[data-grammar="source python"]:not(.mini)':
+'.platform-linux atom-text-editor[data-grammar~=python]:not(.mini)':
   'ctrl-alt-g': 'autocomplete-python:go-to-definition'
 
-'.platform-win32 atom-text-editor[data-grammar="source python"]:not(.mini)':
+'.platform-win32 atom-text-editor[data-grammar~=python]:not(.mini)':
   'ctrl-alt-g': 'autocomplete-python:go-to-definition'


### PR DESCRIPTION
I'm using `python-tools` with this package. I think this is why I cannot use shortcut.

What I did is I found that the grammer is detected as `source python django` so I've added the following to my `keymap.cson`:

        '.platform-linux atom-text-editor[data-grammar*="source python"]:not(.mini)':
          'ctrl-alt-g': 'autocomplete-python:go-to-definition'

And it worked.

Therefore I'm contributing this change.