### PR TITLE
Advanced show usages features

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,27 @@ Python packages, variables, methods and functions with their arguments autocompl
 # Features
 
 * Works with :apple: Mac OSX, :penguin: Linux and :checkered_flag: Windows
+
 * Works with both :snake: Python 2 and 3
+
 * Automatic lookup of virtual environments inside of your projects
+
 * Configurable additional packages to include for completions
+
 * Prints first N characters of statement value while completing variables
+
 * Prints function arguments while completing functions
+
 * Go-to-definition functionality, by default on `Alt+Cmd+G`/`Ctrl+Alt+G` (thanks to [@patrys](https://github.com/patrys))
+
 * If you have [Hyperclick](https://atom.io/packages/hyperclick) installed – you can click on anything to go-to-definition
-![sample](https://cloud.githubusercontent.com/assets/193864/10814177/17fb8bce-7e5f-11e5-8285-6b0100b3a0f8.gif)
+  ![sample](https://cloud.githubusercontent.com/assets/193864/10814177/17fb8bce-7e5f-11e5-8285-6b0100b3a0f8.gif)
+
+* Show usages of selected object
+  ![sample](https://cloud.githubusercontent.com/assets/193864/12263525/aff07ad4-b96a-11e5-949e-598e943b0190.gif)
+
+* Rename across multiple files. It will not touch files outside of your project, but it will change VCS ignored files. I'm not responsible for any broken projects without VCS because of this.
+  ![sample](https://cloud.githubusercontent.com/assets/193864/12288191/f448b55a-ba0c-11e5-81d7-31289ef5dbba.gif)
 
 # Configuration
 

--- a/lib/rename-view.coffee
+++ b/lib/rename-view.coffee
@@ -1,0 +1,27 @@
+{View} = require 'space-pen'
+{TextEditorView} = require 'atom-space-pen-views'
+
+module.exports =
+class RenameView extends View
+  initialize: ->
+    @panel ?= atom.workspace.addModalPanel(item: @, visible: true)
+    atom.commands.add(@element, 'core:cancel', => @destroy())
+
+  destroy: ->
+    @panel.hide()
+    @.focusout()
+    @panel.destroy()
+
+  @content: (usages) ->
+    n = usages.length
+    name = usages[0].name
+    @div =>
+      @div "Type new name to replace #{n} occurences of #{name} within project:"
+      @subview 'miniEditor', new TextEditorView
+        mini: true, placeholderText: name
+
+  onInput: (callback) ->
+    @miniEditor.focus()
+    atom.commands.add @element, 'core:confirm': =>
+      callback(@miniEditor.getText())
+      @destroy()

--- a/lib/usages-view.coffee
+++ b/lib/usages-view.coffee
@@ -25,6 +25,15 @@ class UsagesView extends SelectListView
 
   getFilterKey: -> 'fileName'
 
+  scrollToItemView: ->
+    super
+    {name, moduleName, fileName, line, column} = @getSelectedItem()
+    editor = atom.workspace.getActiveTextEditor()
+    if editor.getBuffer().file.path is fileName
+      editor.setSelectedBufferRange([
+        [line - 1, column], [line - 1, column + name.length]])
+      editor.scrollToBufferPosition([line - 1, column], center: true)
+
   getEmptyMessage: (itemCount) ->
     if itemCount is 0
       'No usages found'

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "fuzzaldrin-plus": "^0.3.1",
     "selector-kit": "^0.1",
     "space-pen": "^5.1.2",
-    "underscore": "^1.8.3",
+    "underscore": "^1.8.3"
   },
   "package-dependencies": {},
   "providedServices": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "atom-slick": "^2.0.0",
     "atom-space-pen-views": "~2.1.0",
     "fuzzaldrin-plus": "^0.3.1",
-    "selector-kit": "^0.1"
+    "selector-kit": "^0.1",
+    "space-pen": "^5.1.2",
+    "underscore": "^1.8.3",
   },
   "package-dependencies": {},
   "providedServices": {


### PR DESCRIPTION
Trying to think about which features we can implement to help with refactoring.

With this https://github.com/atom/atom/pull/10178 we should be able to open pending tabs programatically, thus show & close usages in different files as you scroll. Could be useful if you are looking for something. It is already implemented for single file. *This is different from go-to-definition.*

![sample](https://cloud.githubusercontent.com/assets/193864/12263525/aff07ad4-b96a-11e5-949e-598e943b0190.gif)

Another important feature – smart rename within project. This is something I need to think about. It definitely should be done in Atom side. We already have list of all files with each token to be renamed.

- [x] Add another command which will ask user to type new name of currently selected object
- [x] And, well, rename all the things
- [x] Make rename work with multiple files
- [x] Do not touch files outside of project folders
- [ ] Figure out how to deal with module names: should we touch them or not? If yes – how?