### PR TITLE
[WIP] Show related docstrings in message panel

### DIFF
--- a/lib/completion.py
+++ b/lib/completion.py
@@ -294,7 +294,7 @@ class JediCompletion(object):
             config: Dictionary with config values.
         """
         sys.path = self.default_sys_path
-        self.use_snippet = config.get('useSnippets')
+        self.use_snippets = config.get('useSnippets')
         self.show_doc_strings = config.get('showDescriptions', True)
         self.fuzzy_matcher = config.get('fuzzyMatcher', False)
         jedi.settings.case_insensitive_completion = config.get(

--- a/lib/completion.py
+++ b/lib/completion.py
@@ -243,11 +243,17 @@ class JediCompletion(object):
                     definition = _top_definition(definition)
                 if not definition.module_path:
                   continue
+
+                description = definition.docstring()
+                if description is not None:
+                  description = description.strip()
+                if not description:
+                  description = self._additional_info(definition)
                 _definition = {
                     'text': definition.name,
                     'type': self._get_definition_type(definition),
                     'fileName': definition.module_path,
-                    'description': definition.docstring(),
+                    'description': description,
                     'line': definition.line - 1,
                     'column': definition.column
                 }
@@ -288,7 +294,7 @@ class JediCompletion(object):
             config: Dictionary with config values.
         """
         sys.path = self.default_sys_path
-        self.use_snippets = config.get('useSnippets')
+        self.use_snippet = config.get('useSnippets')
         self.show_doc_strings = config.get('showDescriptions', True)
         self.fuzzy_matcher = config.get('fuzzyMatcher', False)
         jedi.settings.case_insensitive_completion = config.get(

--- a/lib/completion.py
+++ b/lib/completion.py
@@ -247,6 +247,7 @@ class JediCompletion(object):
                     'text': definition.name,
                     'type': self._get_definition_type(definition),
                     'fileName': definition.module_path,
+                    'description': definition.docstring(),
                     'line': definition.line - 1,
                     'column': definition.column
                 }

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -93,6 +93,13 @@ module.exports =
       title: 'Output Debug Logs'
       description: '''Select if you would like to see debug information in
       developer tools logs. May slow down your editor.'''
+    showTooltips:
+      type: 'boolean'
+      default: false
+      order: 10
+      title: 'Show Tooltips with information about the object under the cursor'
+      description: '''EXPERIMENTAL FEATURE WHICH IS NOT FINISHED YET.
+      Feedback and ideas are welcome on github.'''
 
   activate: (state) -> provider.constructor()
 

--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -209,7 +209,6 @@ module.exports =
       event.newBufferPosition)
     scopeChain = scopeDescriptor.getScopeChain()
 
-    log.debug 'scopeDescriptor', scopeDescriptor
     disableForSelector = "#{@disableForSelector}, .source.python .numeric, .source.python .integer, .source.python .decimal, .source.python .punctuation, .source.python .keyword, .source.python .storage, .source.python .variable.parameter, .source.python .entity.name"
     disableForSelector = Selector.create(disableForSelector)
 
@@ -222,7 +221,6 @@ module.exports =
       {persistent: false, invalidate: 'never'})
 
     @markers.push(marker)
-    log.debug('marker', marker)
 
     getTooltip = (editor, bufferPosition) =>
       payload =
@@ -243,7 +241,6 @@ module.exports =
 
         description = description.trim()
         if not description
-          log.debug 'empty description content'
           return
         view = document.createElement('autocomplete-python-suggestion')
         view.appendChild(document.createTextNode(description))
@@ -253,8 +250,6 @@ module.exports =
             position: 'head'
         })
         log.debug('decorated marker', marker)
-      else
-        log.debug('no definition found')
 
   _handleGrammarChangeEvent: (editor, grammar) ->
     eventName = 'keyup'
@@ -355,8 +350,6 @@ module.exports =
 
   _generateRequestId: (type, editor, bufferPosition, text) ->
     if not text
-      if not editor.getText
-        console.log 'if not editor.getText!!!!', editor
       text = editor.getText()
     return require('crypto').createHash('md5').update([
       editor.getPath(), text, bufferPosition.row,

--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -8,6 +8,7 @@ RenameView = require './rename-view'
 InterpreterLookup = require './interpreters-lookup'
 log = require './log'
 _ = require 'underscore'
+{MessagePanelView, LineMessageView} = require 'atom-message-panel'
 filter = undefined
 
 module.exports =
@@ -166,6 +167,14 @@ module.exports =
     atom.config.onDidChange 'autocomplete-plus.enableAutoActivation', =>
       atom.workspace.observeTextEditors (editor) =>
         @_handleGrammarChangeEvent(editor, editor.getGrammar())
+
+    messages = new MessagePanelView
+      title: 'Remember your Coffee!'
+    messages.attach()
+    messages.add new LineMessageView
+      line: 1
+      character: 4
+      message: 'You haven\'t had a single drop of coffee since this character'
 
   _updateUsagesInFile: (fileName, usages, newName) ->
     columnOffset = {}

--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -224,7 +224,20 @@ module.exports =
     @markers.push(marker)
     log.debug('marker', marker)
 
-    @getDefinitions(editor, event.newBufferPosition).then (results) =>
+    getTooltip = (editor, bufferPosition) =>
+      payload =
+        id: @_generateRequestId('tooltip', editor, bufferPosition)
+        lookup: 'tooltip'
+        path: editor.getPath()
+        source: editor.getText()
+        line: bufferPosition.row
+        column: bufferPosition.column
+        config: @_generateRequestConfig()
+      @_sendRequest(@_serialize(payload))
+      return new Promise (resolve) =>
+        @requests[payload.id] = resolve
+
+    getTooltip(editor, event.newBufferPosition).then (results) =>
       if results.length > 0
         {text, fileName, line, column, type, description} = results[0]
 

--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -175,24 +175,47 @@ module.exports =
       atom.workspace.observeTextEditors (editor) =>
         @_handleGrammarChangeEvent(editor, editor.getGrammar())
 
-    messages = new MessagePanelView
-      title: "_serialize_completions(self, script, identifier=None, prefix='')"
-    messages.attach()
-    # messages.add new PlainMessageView
-    messages.add new LineMessageView
-      line: 1
-      character: 4
-      message: 'Serialize response to be read from Atom.'
-      preview: '''Serialize response to be read from Atom.
+    # docs
+    editor = atom.workspace.getActiveTextEditor()
 
-      Args:
-          script: Instance of jedi.api.Script object.
-          identifier: Unique completion identifier to pass back to Atom.
-          prefix: String with prefix to filter function arguments.
-              Used only when fuzzy matcher turned off.
+    marker = editor.markBufferRange(
+      [[0, 0], [0, 10]], {persistent: false, invalidate: 'never'})
 
-      Returns:
-          Serialized string to send to Atom.'''
+    log.debug('marker', marker)
+
+    el = document.createElement('div')
+    el.setAttribute('style', 'background-color: green;')
+    newContent = document.createTextNode('Hi there and greetings!')
+    el.appendChild(newContent)
+
+    log.debug('el', el)
+
+    editor.decorateMarker(
+      marker, {
+        type: 'overlay',
+        class: 'signature-help',
+        item: el,
+        position: 'head'
+    })
+
+    # messages = new MessagePanelView
+    #   title: "_serialize_completions(self, script, identifier=None, prefix='')"
+    # messages.attach()
+    # # messages.add new PlainMessageView
+    # messages.add new LineMessageView
+    #   line: 1
+    #   character: 4
+    #   message: 'Serialize response to be read from Atom.'
+    #   preview: '''Serialize response to be read from Atom.
+    #
+    #   Args:
+    #       script: Instance of jedi.api.Script object.
+    #       identifier: Unique completion identifier to pass back to Atom.
+    #       prefix: String with prefix to filter function arguments.
+    #           Used only when fuzzy matcher turned off.
+    #
+    #   Returns:
+    #       Serialized string to send to Atom.'''
 
   _updateUsagesInFile: (fileName, usages, newName) ->
     columnOffset = {}

--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -270,60 +270,24 @@ module.exports =
 
     log.debug('marker', marker)
 
-    view = document.createElement('autocomplete-suggestion-list')
-
     @getDefinitions(editor, event.newBufferPosition).then (results) =>
       if results.length > 0
         {text, fileName, line, column, type, description} = results[0]
 
-        # view.setAttribute('class', 'popover-list select-list autocomplete-suggestion-list')
-        #
-        # desc = document.createElement('div')
-        # desc.setAttribute('class', 'suggestion-description')
-        # desc.setAttribute('style', 'display: block;')
-        #
-        # span = document.createElement('span')
-        # span.setAttribute('class', 'suggestion-description-content')
-        # span.appendChild(document.createTextNode('test!'))
-        #
-        # desc.appendChild(span)
-        # view.appendChild(desc)
+        description = description.trim()
+        if not description
+          log.debug 'empty description content'
+          return
 
-        view.maxItems = 1
-
-        log.debug('newView1', view)
-        log.debug('newView2', view.maxItems)
-        log.debug('newView7', view.descriptionContent)
-
-        view.createdCallback = -> log.debug 'created callback!!!!1111111111'
-
-        view.attachedCallback = -> log.debug 'attachedCallback'
-
-        # view.createdCallback()
-
-        # view.onload ->
-        #   log.debug 'ON LOAD', view.querySelector('.suggestion-description-content')
-        #
-        # view.onshow ->
-        #   log.debug 'ON show', view.querySelector('.suggestion-description-content')
-
-        # log.debug 'selector', view.querySelector('.suggestion-description-content')
-
-        setTimeout(->
-          console.log('wake up')
-          view.querySelector('.suggestion-description-content').appendChild(document.createTextNode(description))
-        , 100)
+        view = document.createElement('autocomplete-python-suggestion')
+        view.appendChild(document.createTextNode(description))
 
         decoration = editor.decorateMarker(marker, {
             type: 'overlay',
-            class: 'autocomplete-plus',
             item: view,
             position: 'head'
         })
         log.debug('decorated marker', marker)
-        # bla = view.querySelector('.suggestion-description-content')
-        # bla.appendChild(document.createTextNode('appended child2'))
-        # log.debug 'selector', view.querySelector('.suggestion-description-content')
       else
         log.debug('no definition found')
 

--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -8,7 +8,7 @@ RenameView = require './rename-view'
 InterpreterLookup = require './interpreters-lookup'
 log = require './log'
 _ = require 'underscore'
-{MessagePanelView, LineMessageView} = require 'atom-message-panel'
+{MessagePanelView, LineMessageView, PlainMessageView} = require 'atom-message-panel'
 filter = undefined
 
 module.exports =
@@ -169,12 +169,23 @@ module.exports =
         @_handleGrammarChangeEvent(editor, editor.getGrammar())
 
     messages = new MessagePanelView
-      title: 'Remember your Coffee!'
+      title: "_serialize_completions(self, script, identifier=None, prefix='')"
     messages.attach()
+    # messages.add new PlainMessageView
     messages.add new LineMessageView
       line: 1
       character: 4
-      message: 'You haven\'t had a single drop of coffee since this character'
+      message: 'Serialize response to be read from Atom.'
+      preview: '''Serialize response to be read from Atom.
+
+      Args:
+          script: Instance of jedi.api.Script object.
+          identifier: Unique completion identifier to pass back to Atom.
+          prefix: String with prefix to filter function arguments.
+              Used only when fuzzy matcher turned off.
+
+      Returns:
+          Serialized string to send to Atom.'''
 
   _updateUsagesInFile: (fileName, usages, newName) ->
     columnOffset = {}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "atom": ">=0.194.0 <2.0.0"
   },
   "dependencies": {
-    "atom-message-panel": "^1.2.4",
     "atom-slick": "^2.0.0",
     "atom-space-pen-views": "~2.1.0",
     "fuzzaldrin-plus": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "atom": ">=0.194.0 <2.0.0"
   },
   "dependencies": {
+    "atom-message-panel": "^1.2.4",
     "atom-slick": "^2.0.0",
     "atom-space-pen-views": "~2.1.0",
     "fuzzaldrin-plus": "^0.3.1",

--- a/styles/autocomplete-python.less
+++ b/styles/autocomplete-python.less
@@ -28,7 +28,6 @@ autocomplete-python-suggestion {
   border-radius: 0 0 @component-border-radius @component-border-radius;
 
   max-height: @font-size * @line-height * 20;
-  // overflow-x: hidden;
   overflow-y: scroll;
 
   white-space: pre-wrap;

--- a/styles/autocomplete-python.less
+++ b/styles/autocomplete-python.less
@@ -1,5 +1,36 @@
+@import "ui-variables";
+
 atom-text-editor[data-grammar="source python"], :host {
   .autocomplete-suggestion-list.select-list.popover-list .suggestion-description-content {
     white-space: pre-wrap;
   }
+}
+
+
+@row-line-height: 2em;
+@item-side-padding: .6em;
+@line-height: 1.3;
+
+autocomplete-python-suggestion {
+  width: auto;
+  display: inline-block;
+  min-width: 200px;
+  max-width: 800px;
+  color: @text-color;
+
+  padding: 5px 0;
+  padding-left: @item-side-padding;
+  padding-right: @item-side-padding;
+  min-height: @row-line-height;
+  line-height: @line-height;
+
+  background: darken(@overlay-background-color, 4%);
+  border-radius: 0 0 @component-border-radius @component-border-radius;
+
+  max-height: @font-size * @line-height * 20;
+  // overflow-x: hidden;
+  overflow-y: scroll;
+
+  white-space: pre-wrap;
+  font-family: @font-family;
 }


### PR DESCRIPTION
![sample](https://cloud.githubusercontent.com/assets/193864/13423120/116ba128-dfd4-11e5-8eff-4f4666030880.gif)

We can get a docstring of object which is currently under a cursor using go to definition.
Another option is to only lookup for docstrings when you select entire object name.
But probably lookup of each object under a cursor should be ok. Need to limit the scopes so we will not call it on non-related stuff.

Another option is to only activate it on specific command call.

https://atom.io/docs/api/v1.5.3/Cursor#instance-onDidChangePosition

Closes #181

https://github.com/atom/atom/issues/9936